### PR TITLE
UPSTREAM-138, part 2: Fix block layout

### DIFF
--- a/web/sites/default/config/block.block.penn_starter_account_menu.yml
+++ b/web/sites/default/config/block.block.penn_starter_account_menu.yml
@@ -1,0 +1,27 @@
+uuid: 2fc87716-b9ba-46c9-a13a-b21503b5f668
+langcode: en
+status: true
+dependencies:
+  config:
+    - system.menu.account
+  module:
+    - system
+  theme:
+    - penn_starter
+_core:
+  default_config_hash: 8a31Ywc1t2zlddGd3bmDrFMefWqgSK2E02ceFdr-bfc
+id: penn_starter_account_menu
+theme: penn_starter
+region: hidden
+weight: 3
+provider: null
+plugin: 'system_menu_block:account'
+settings:
+  id: 'system_menu_block:account'
+  label: 'User account menu'
+  provider: system
+  label_display: '0'
+  level: 1
+  depth: 1
+  expand_all_items: false
+visibility: {  }

--- a/web/sites/default/config/block.block.penn_starter_branding.yml
+++ b/web/sites/default/config/block.block.penn_starter_branding.yml
@@ -1,0 +1,25 @@
+uuid: 73a09a38-e56b-430f-b080-0528d872b254
+langcode: en
+status: true
+dependencies:
+  module:
+    - system
+  theme:
+    - penn_starter
+_core:
+  default_config_hash: NDwadleLD3YVSbDUaakxyYZyINYtkFtOVGShfq4kWy8
+id: penn_starter_branding
+theme: penn_starter
+region: hidden
+weight: -3
+provider: null
+plugin: system_branding_block
+settings:
+  id: system_branding_block
+  label: 'Site branding'
+  provider: system
+  label_display: '0'
+  use_site_logo: true
+  use_site_name: true
+  use_site_slogan: true
+visibility: {  }

--- a/web/sites/default/config/block.block.penn_starter_breadcrumbs.yml
+++ b/web/sites/default/config/block.block.penn_starter_breadcrumbs.yml
@@ -1,0 +1,22 @@
+uuid: 06f5a2f8-2bf7-4075-8c83-fc807ec8ba66
+langcode: en
+status: true
+dependencies:
+  module:
+    - system
+  theme:
+    - penn_starter
+_core:
+  default_config_hash: oXUb3JZR2WW5VOdw4HrhRicCsq51mCgLfRyvheG68ck
+id: penn_starter_breadcrumbs
+theme: penn_starter
+region: hidden
+weight: 5
+provider: null
+plugin: system_breadcrumb_block
+settings:
+  id: system_breadcrumb_block
+  label: Breadcrumbs
+  provider: system
+  label_display: '0'
+visibility: {  }

--- a/web/sites/default/config/block.block.penn_starter_content.yml
+++ b/web/sites/default/config/block.block.penn_starter_content.yml
@@ -1,0 +1,22 @@
+uuid: ca9e054d-6233-45fc-b6aa-80562e806a69
+langcode: en
+status: true
+dependencies:
+  module:
+    - system
+  theme:
+    - penn_starter
+_core:
+  default_config_hash: 9EoWV2Lot6FVSr50t4hoKgiz1LIXYWNG-IIPYsWxBqo
+id: penn_starter_content
+theme: penn_starter
+region: content
+weight: -5
+provider: null
+plugin: system_main_block
+settings:
+  id: system_main_block
+  label: 'Main page content'
+  provider: system
+  label_display: '0'
+visibility: {  }

--- a/web/sites/default/config/block.block.penn_starter_footer.yml
+++ b/web/sites/default/config/block.block.penn_starter_footer.yml
@@ -1,0 +1,27 @@
+uuid: aa303eee-0e21-4952-879d-4f2101c8efbb
+langcode: en
+status: true
+dependencies:
+  config:
+    - system.menu.footer
+  module:
+    - system
+  theme:
+    - penn_starter
+_core:
+  default_config_hash: 8zRjTNbfNAJ94lQpZDu6MkyD87GYJ2zpH9VQPVmRbcM
+id: penn_starter_footer
+theme: penn_starter
+region: hidden
+weight: -1
+provider: null
+plugin: 'system_menu_block:footer'
+settings:
+  id: 'system_menu_block:footer'
+  label: 'Footer menu'
+  provider: system
+  label_display: '0'
+  level: 1
+  depth: 0
+  expand_all_items: false
+visibility: {  }

--- a/web/sites/default/config/block.block.penn_starter_help.yml
+++ b/web/sites/default/config/block.block.penn_starter_help.yml
@@ -1,0 +1,22 @@
+uuid: d00f3704-5985-4cc9-84ad-cd7cfcdbdd6b
+langcode: en
+status: true
+dependencies:
+  module:
+    - help
+  theme:
+    - penn_starter
+_core:
+  default_config_hash: 8I8iACSa0sKO3k3jlvUG1ge52rfcKX7USJAQYnzuBgg
+id: penn_starter_help
+theme: penn_starter
+region: hidden
+weight: -5
+provider: null
+plugin: help_block
+settings:
+  id: help_block
+  label: Help
+  provider: help
+  label_display: '0'
+visibility: {  }

--- a/web/sites/default/config/block.block.penn_starter_local_actions.yml
+++ b/web/sites/default/config/block.block.penn_starter_local_actions.yml
@@ -1,0 +1,20 @@
+uuid: 895909a6-c8b9-4b52-99d9-d5af112f5417
+langcode: en
+status: true
+dependencies:
+  theme:
+    - penn_starter
+_core:
+  default_config_hash: 13GQpeITIJsp1kyPniXtWZfyFH87vb1xxJCHifL4UeE
+id: penn_starter_local_actions
+theme: penn_starter
+region: hidden
+weight: -4
+provider: null
+plugin: local_actions_block
+settings:
+  id: local_actions_block
+  label: 'Primary admin actions'
+  provider: core
+  label_display: '0'
+visibility: {  }

--- a/web/sites/default/config/block.block.penn_starter_local_tasks.yml
+++ b/web/sites/default/config/block.block.penn_starter_local_tasks.yml
@@ -1,0 +1,22 @@
+uuid: 26fccd8b-92fd-423d-9572-981867b715ee
+langcode: en
+status: true
+dependencies:
+  theme:
+    - penn_starter
+_core:
+  default_config_hash: X9I1OB0W3WlWtrK-CNcg6hNWwa8wficanpH8pYnDZDE
+id: penn_starter_local_tasks
+theme: penn_starter
+region: prefix
+weight: -6
+provider: null
+plugin: local_tasks_block
+settings:
+  id: local_tasks_block
+  label: Tabs
+  provider: core
+  label_display: '0'
+  primary: true
+  secondary: true
+visibility: {  }

--- a/web/sites/default/config/block.block.penn_starter_main_menu.yml
+++ b/web/sites/default/config/block.block.penn_starter_main_menu.yml
@@ -1,0 +1,27 @@
+uuid: b0a75e4c-efa5-4183-8430-6b916593a747
+langcode: en
+status: true
+dependencies:
+  config:
+    - system.menu.main
+  module:
+    - system
+  theme:
+    - penn_starter
+_core:
+  default_config_hash: ChCx7DYNUrPTt5uiRdQAPDKJQMc-_SyAQTrZh8H0o-c
+id: penn_starter_main_menu
+theme: penn_starter
+region: hidden
+weight: -2
+provider: null
+plugin: 'system_menu_block:main'
+settings:
+  id: 'system_menu_block:main'
+  label: 'Main navigation'
+  provider: system
+  label_display: '0'
+  level: 1
+  depth: 1
+  expand_all_items: false
+visibility: {  }

--- a/web/sites/default/config/block.block.penn_starter_messages.yml
+++ b/web/sites/default/config/block.block.penn_starter_messages.yml
@@ -1,0 +1,22 @@
+uuid: 89286c19-319c-4ad7-8299-0635e5e74a92
+langcode: en
+status: true
+dependencies:
+  module:
+    - system
+  theme:
+    - penn_starter
+_core:
+  default_config_hash: KHQIJ7Vfl25lTjzIc7qIvnuistt-Mw2O0kG4jCofmkI
+id: penn_starter_messages
+theme: penn_starter
+region: hidden
+weight: 1
+provider: null
+plugin: system_messages_block
+settings:
+  id: system_messages_block
+  label: 'Status messages'
+  provider: system
+  label_display: '0'
+visibility: {  }

--- a/web/sites/default/config/block.block.penn_starter_page_title.yml
+++ b/web/sites/default/config/block.block.penn_starter_page_title.yml
@@ -1,0 +1,20 @@
+uuid: b25990b4-829b-4846-8de1-d7b65b055e36
+langcode: en
+status: true
+dependencies:
+  theme:
+    - penn_starter
+_core:
+  default_config_hash: 7rR9chwXvdM2H8OYMAYx9Zj3GGlPMrZp_M3ZA4thYTk
+id: penn_starter_page_title
+theme: penn_starter
+region: hidden
+weight: -6
+provider: null
+plugin: page_title_block
+settings:
+  id: page_title_block
+  label: 'Page title'
+  provider: core
+  label_display: '0'
+visibility: {  }

--- a/web/sites/default/config/block.block.penn_starter_powered.yml
+++ b/web/sites/default/config/block.block.penn_starter_powered.yml
@@ -1,0 +1,22 @@
+uuid: 8cc787c5-eaa1-4a90-b90b-e76e9869a9b9
+langcode: en
+status: true
+dependencies:
+  module:
+    - system
+  theme:
+    - penn_starter
+_core:
+  default_config_hash: jQQUUWN2Uxr5qZtc9zcJKBCxpKY8orN1u2HPqYYRQDI
+id: penn_starter_powered
+theme: penn_starter
+region: hidden
+weight: 2
+provider: null
+plugin: system_powered_by_block
+settings:
+  id: system_powered_by_block
+  label: 'Powered by Drupal'
+  provider: system
+  label_display: '0'
+visibility: {  }

--- a/web/sites/default/config/block.block.penn_starter_search.yml
+++ b/web/sites/default/config/block.block.penn_starter_search.yml
@@ -1,0 +1,23 @@
+uuid: 1204c2f2-8e6b-4bc4-bdf5-da3efc2e31ba
+langcode: en
+status: true
+dependencies:
+  module:
+    - search
+  theme:
+    - penn_starter
+_core:
+  default_config_hash: za-39d5WDUg6XvbyqSnuVYEeq6QM4qKJxW8MnoAha5A
+id: penn_starter_search
+theme: penn_starter
+region: hidden
+weight: 4
+provider: null
+plugin: search_form_block
+settings:
+  id: search_form_block
+  label: Search
+  provider: search
+  label_display: visible
+  page_id: ''
+visibility: {  }

--- a/web/sites/default/config/block.block.penn_starter_tools.yml
+++ b/web/sites/default/config/block.block.penn_starter_tools.yml
@@ -1,0 +1,27 @@
+uuid: 0072fcba-131e-4c01-a083-bd277fa421c4
+langcode: en
+status: true
+dependencies:
+  config:
+    - system.menu.tools
+  module:
+    - system
+  theme:
+    - penn_starter
+_core:
+  default_config_hash: rH6PpAn7-RScha1rGkohGAYSSh_1OVeZzioJPzPw6O4
+id: penn_starter_tools
+theme: penn_starter
+region: hidden
+weight: 0
+provider: null
+plugin: 'system_menu_block:tools'
+settings:
+  id: 'system_menu_block:tools'
+  label: Tools
+  provider: system
+  label_display: visible
+  level: 1
+  depth: 0
+  expand_all_items: false
+visibility: {  }

--- a/web/sites/default/config/block.block.penn_starter_views_block__alert_block.yml
+++ b/web/sites/default/config/block.block.penn_starter_views_block__alert_block.yml
@@ -1,0 +1,24 @@
+uuid: 9872b2b2-6a7e-42ec-bce5-4df97bfeea15
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.alert
+  module:
+    - views
+  theme:
+    - penn_starter
+id: penn_starter_views_block__alert_block
+theme: penn_starter
+region: alert
+weight: 0
+provider: null
+plugin: 'views_block:alert-alert_block'
+settings:
+  id: 'views_block:alert-alert_block'
+  label: ''
+  provider: views
+  label_display: '0'
+  views_label: ''
+  items_per_page: none
+visibility: {  }

--- a/web/themes/custom/penn_global/assets/dist/site.css
+++ b/web/themes/custom/penn_global/assets/dist/site.css
@@ -12372,7 +12372,8 @@ a.text-cta__taxonomy:hover, a.text-cta__taxonomy:focus {
 /**
  * Local Tasks Menu
  */
-#block-penn-global-local-tasks {
+#block-penn-global-local-tasks,
+#block-penn-starter-local-tasks {
   z-index: 10;
   top: 200px;
   right: 0;
@@ -12382,14 +12383,16 @@ a.text-cta__taxonomy:hover, a.text-cta__taxonomy:focus {
   border: 2px solid #ddd;
 }
 
-#block-penn-global-local-tasks li {
+#block-penn-global-local-tasks li,
+#block-penn-starter-local-tasks li {
   margin: 0 10px;
   list-style-type: none;
   color: #95001A;
   margin: 6px 0;
 }
 
-#block-penn-global-local-tasks li a {
+#block-penn-global-local-tasks li a,
+#block-penn-starter-local-tasks li a {
   color: #95001A;
   font-size: 14px;
 }

--- a/web/themes/custom/penn_global/assets/scss/custom/_custom.scss
+++ b/web/themes/custom/penn_global/assets/scss/custom/_custom.scss
@@ -202,7 +202,8 @@
  * Local Tasks Menu
  */
 
-#block-penn-global-local-tasks {
+#block-penn-global-local-tasks,
+#block-penn-starter-local-tasks {
   z-index: 10;
   top: 200px;
   right: 0;


### PR DESCRIPTION
This PR repairs the floating "local tasks" menu and the alerts block. Import the config in this PR with a `drush cim` and you'll be good to go.

- The problem wasn't caused by `structure_sync`. The block layout just didn't get generated & exported into config. 
  - It's a [long story](https://www.drupal.org/project/drupal/issues/2635978), the short of it is "it just happens sometimes". Subthemes are finicky and only inherit block config in limited circumstances; I got unlucky, and didn't notice.

- The menu's CSS also needed slight adjustment, because the block ID changes depending on the theme name.
  - I changed the CSS in `penn_global` instead of duplicating it in the subtheme, so that if menu needs style adjustments later, the work will be done in one place.
