### PR TITLE
Fix Search Console verification

### DIFF
--- a/web/themes/custom/penn_global/templates/system/html.html.twig
+++ b/web/themes/custom/penn_global/templates/system/html.html.twig
@@ -50,6 +50,7 @@
     ]
   %}
       <body{{attributes.addClass(body_classes)}}>
+        {{ page_top }}
         <div id="top">
           <div class="skip-links">
             <a class="skip-link" href="#content">Skip to main content</a>
@@ -71,7 +72,6 @@
               <path d="M19.169 2.623c.507-.508.518-1.32.023-1.815-.494-.495-1.307-.484-1.815.023L.831 17.377c-.507.508-.518 1.32-.023 1.815.494.495 1.307.484 1.815-.023L19.169 2.623zM2.623.83C2.115.324 1.303.313.808.808.313 1.302.324 2.115.83 2.623l16.546 16.546c.508.507 1.32.518 1.815.023.495-.494.484-1.307-.023-1.815L2.623.831z" fill-rule="nonzero"/>
             </symbol>
           </svg>
-          {{ page_top }}
           {{ page }}
           {{ page_bottom }}
         </div>


### PR DESCRIPTION
Pushing this up to be rolled into a future release at your leisure. :-)

This was originally [discussed in PP-5](https://pennweb.atlassian.net/browse/PP-5). Google Search Console verification has been failing because the Tag Manager snippet is in the wrong place on the page. 

Since GTM was installed on our sites with the google_tag module, it's being inserted with the `page_top` template hook. In our template, there are skip links between the start of `<body>` and `page_top`, making Google unhappy.

This commit moves `page_top` immediately after `<body>`. That's it.